### PR TITLE
Update .gitmodules To Use Calinou's New Repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,10 +18,10 @@
 	url = https://github.com/VanessaE/plantlife.git
 [submodule "mods/moreblocks"]
 	path = mods/moreblocks
-	url = https://github.com/Calinou/moreblocks.git
+	url = https://gitorious.org/calinou/moreblocks.git
 [submodule "mods/moreores"]
 	path = mods/moreores
-	url = https://github.com/Calinou/moreores.git
+	url = https://gitorious.org/calinou/moreores.git
 [submodule "mods/forth_computer"]
 	path = mods/forth_computer
 	url = https://github.com/Novatux/forth_computer.git


### PR DESCRIPTION
Calinou has moved his moreores and moreblocks repos to Gitorious. I've updated the .gitmodules to use these new locations, instead of failing when you update/init the submodules. Tested and working.
