### PR TITLE
updated swap_node call to match mesecons

### DIFF
--- a/mods/digilines_converters/init.lua
+++ b/mods/digilines_converters/init.lua
@@ -131,7 +131,7 @@ minetest.register_node("digilines_converters:m2d_converter_off", {
 			action_on = function(pos, node)
 				local c = minetest.get_meta(pos):get_string("channel")
 				digiline:receptor_send(pos, rotate_rules(node, {{x=-1,y=0,z=0}}), c, "on")
-				minetest.swap_node(pos, {name="digilines_converters:m2d_converter_on"})
+				minetest.swap_node(pos, {name="digilines_converters:m2d_converter_on", param2 = node.param2})
 			end,
 			action_off = function(pos, node)
 				local c = minetest.get_meta(pos):get_string("channel")
@@ -182,7 +182,7 @@ minetest.register_node("digilines_converters:m2d_converter_on", {
 			action_off = function(pos, node)
 				local c = minetest.get_meta(pos):get_string("channel")
 				digiline:receptor_send(pos, rotate_rules(node, {{x=-1,y=0,z=0}}), c, "off")
-				minetest.swap_node(pos, {name="digilines_converters:m2d_converter_off"})
+				minetest.swap_node(pos, {name="digilines_converters:m2d_converter_off", param2 = node.param2})
 			end,
 		},
 	},

--- a/mods/digilines_converters/init.lua
+++ b/mods/digilines_converters/init.lua
@@ -1,6 +1,6 @@
 local function rotate_rules(node, rules)
 	for rotations = 1, node.param2 do
-		rules = mesecon:rotate_rules_left(rules)
+		rules = mesecon.rotate_rules_left(rules)
 	end
 	return rules
 end
@@ -18,11 +18,11 @@ local on_digiline_receive = function (pos, node, channel, msg)
 	local chan = minetest.get_meta(pos):get_string("channel")
 	if channel == chan then
 		if node.name == "digilines_converters:d2m_converter_off" and msg == "on" then
-			mesecon:swap_node(pos, "digilines_converters:d2m_converter_on")
-			mesecon:receptor_on(pos, rotate_rules(node, {{x=1,y=0,z=0}}))
+			minetest.swap_node(pos, {name="digilines_converters:d2m_converter_on"})
+			mesecon.receptor_on(pos, rotate_rules(node, {{x=1,y=0,z=0}}))
 		elseif node.name == "digilines_converters:d2m_converter_on" and msg == "off" then
-			mesecon:swap_node(pos, "digilines_converters:d2m_converter_off")
-			mesecon:receptor_off(pos, rotate_rules(node, {{x=1,y=0,z=0}}))
+			minetest.swap_node(pos, {name="digilines_converters:d2m_converter_off"})
+			mesecon.receptor_off(pos, rotate_rules(node, {{x=1,y=0,z=0}}))
 		end
 	end
 end
@@ -36,7 +36,7 @@ minetest.register_node("digilines_converters:d2m_converter_off", {
 	sunlight_propagates = true,
 	groups = {dig_immediate=2, mesecon=2},
 	node_box = converter_nbx,
-	digiline = 
+	digiline =
 	{
 		effector = {
 			rules = function(node)
@@ -75,7 +75,7 @@ minetest.register_node("digilines_converters:d2m_converter_on", {
 	sunlight_propagates = true,
 	groups = {dig_immediate=2, mesecon=2, not_in_creative_inventory=1},
 	node_box = converter_nbx,
-	digiline = 
+	digiline =
 	{
 		effector = {
 			rules = function(node)
@@ -113,7 +113,7 @@ minetest.register_node("digilines_converters:m2d_converter_off", {
 	sunlight_propagates = true,
 	groups = {dig_immediate=2, mesecon=2},
 	node_box = converter_nbx,
-	digiline = 
+	digiline =
 	{
 		receptor =
 		{
@@ -131,7 +131,7 @@ minetest.register_node("digilines_converters:m2d_converter_off", {
 			action_on = function(pos, node)
 				local c = minetest.get_meta(pos):get_string("channel")
 				digiline:receptor_send(pos, rotate_rules(node, {{x=-1,y=0,z=0}}), c, "on")
-				mesecon:swap_node(pos, "digilines_converters:m2d_converter_on")
+				minetest.swap_node(pos, {name="digilines_converters:m2d_converter_on"})
 			end,
 			action_off = function(pos, node)
 				local c = minetest.get_meta(pos):get_string("channel")
@@ -160,7 +160,7 @@ minetest.register_node("digilines_converters:m2d_converter_on", {
 	drop = "digilines_converters:m2d_converter_off",
 	groups = {dig_immediate=2, mesecon=2, not_in_creative_inventory=1},
 	node_box = converter_nbx,
-	digiline = 
+	digiline =
 	{
 		receptor =
 		{
@@ -182,7 +182,7 @@ minetest.register_node("digilines_converters:m2d_converter_on", {
 			action_off = function(pos, node)
 				local c = minetest.get_meta(pos):get_string("channel")
 				digiline:receptor_send(pos, rotate_rules(node, {{x=-1,y=0,z=0}}), c, "off")
-				mesecon:swap_node(pos, "digilines_converters:m2d_converter_off")
+				minetest.swap_node(pos, {name="digilines_converters:m2d_converter_off"})
 			end,
 		},
 	},

--- a/mods/digilines_converters/init.lua
+++ b/mods/digilines_converters/init.lua
@@ -18,10 +18,10 @@ local on_digiline_receive = function (pos, node, channel, msg)
 	local chan = minetest.get_meta(pos):get_string("channel")
 	if channel == chan then
 		if node.name == "digilines_converters:d2m_converter_off" and msg == "on" then
-			minetest.swap_node(pos, {name="digilines_converters:d2m_converter_on"})
+			minetest.swap_node(pos, {name="digilines_converters:d2m_converter_on", param2 = node.param2})
 			mesecon.receptor_on(pos, rotate_rules(node, {{x=1,y=0,z=0}}))
 		elseif node.name == "digilines_converters:d2m_converter_on" and msg == "off" then
-			minetest.swap_node(pos, {name="digilines_converters:d2m_converter_off"})
+			minetest.swap_node(pos, {name="digilines_converters:d2m_converter_off", param2 = node.param2})
 			mesecon.receptor_off(pos, rotate_rules(node, {{x=1,y=0,z=0}}))
 		end
 	end

--- a/mods/mesecons_wireless/init.lua
+++ b/mods/mesecons_wireless/init.lua
@@ -83,8 +83,8 @@ minetest.register_node("mesecons_wireless:emitter", {
 				local channel = meta:get_string("channel")
 				local w = get_wireless_receivers(channel)
 				for _,i in ipairs(w) do
-					mesecon:receptor_on(i)
-					mesecon:swap_node(i, "mesecons_wireless:receiver_on")
+					mesecon.receptor_on(i)
+					minetest.swap_node(i, {name="mesecons_wireless:receiver_on"})
 				end
 			end,
 			action_off = function(pos)
@@ -92,8 +92,8 @@ minetest.register_node("mesecons_wireless:emitter", {
 				local channel = meta:get_string("channel")
 				local w = get_wireless_receivers(channel)
 				for _,i in ipairs(w) do
-					mesecon:receptor_off(i)
-					mesecon:swap_node(i, "mesecons_wireless:receiver")
+					mesecon.receptor_off(i)
+					minetest.swap_node(i, {name="mesecons_wireless:receiver"})
 				end
 			end,
 		}


### PR DESCRIPTION
Some earlier changes to mesecons didn't make it into mesecons_wireless or digilines_converters, and caused the server to crash as the function had been removed from mesecons.

Possibly other things I've missed, just adding things as I try them in the game.
